### PR TITLE
Add all files needed to reproduce ImageNet experiments

### DIFF
--- a/src/datasets.py
+++ b/src/datasets.py
@@ -1,5 +1,7 @@
 import numpy as np
 import tensorflow_datasets as tfds
+from torchvision import datasets, transforms
+import torch, os
 
 def load_cifar10():
   """Return the training and test datasets, as jnp.array's."""
@@ -55,3 +57,53 @@ def load_cifar100_split():
   train_ds, test_ds = load_cifar100()
   s1, s2 = _split_cifar(train_ds, label_split=50)
   return s1, s2, test_ds
+
+class ImageNet:
+    def __init__(self):
+        super(ImageNet, self).__init__()
+
+        data_root = "/tmp"
+
+        # Data loading code
+        kwargs = {"num_workers": 4}
+
+        # Data loading code
+        traindir = os.path.join(data_root, "train")
+        valdir = os.path.join(data_root, "val")
+
+        normalize = transforms.Normalize(
+            mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+        )
+
+        train_dataset = datasets.ImageFolder(
+            traindir,
+            transforms.Compose(
+                [
+                    transforms.RandomResizedCrop(224),
+                    transforms.RandomHorizontalFlip(),
+                    transforms.ToTensor(),
+                    normalize,
+                ]
+            ),
+        )
+
+        self.train_loader = torch.utils.data.DataLoader(
+            train_dataset, batch_size=1000, shuffle=True, **kwargs
+        )
+
+        self.val_loader = torch.utils.data.DataLoader(
+            datasets.ImageFolder(
+                valdir,
+                transforms.Compose(
+                    [
+                        transforms.Resize(256),
+                        transforms.CenterCrop(224),
+                        transforms.ToTensor(),
+                        normalize,
+                    ]
+                ),
+            ),
+            batch_size=1000,
+            shuffle=False,
+            **kwargs
+        )

--- a/src/imagenet_resnet50_weight_matching.py
+++ b/src/imagenet_resnet50_weight_matching.py
@@ -1,0 +1,225 @@
+import argparse
+import pickle
+from pathlib import Path
+import jax
+import torch
+torch.set_default_tensor_type(torch.FloatTensor)
+
+import jax.numpy as jnp
+import matplotlib.pyplot as plt
+import wandb
+from flax.serialization import from_bytes
+from jax import random
+from tqdm import tqdm
+
+from resnet import ResNet50
+from cifar10_resnet20_train import BLOCKS_PER_GROUP, ResNet, make_stuff
+from datasets import ImageNet
+from utils import ec2_get_instance_type, flatten_params, lerp, unflatten_params
+from weight_matching import (
+    apply_permutation,
+    resnet50_permutation_spec,
+    weight_matching,
+)
+import pickle
+
+import numpy as np
+import torchmetrics
+import tqdm
+
+
+def plot_interp_loss(
+    epoch,
+    lambdas,
+    train_loss_interp_naive,
+    test_loss_interp_naive,
+    train_loss_interp_clever,
+    test_loss_interp_clever,
+):
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+    ax.plot(
+        lambdas,
+        train_loss_interp_naive,
+        linestyle="dashed",
+        color="tab:blue",
+        alpha=0.5,
+        linewidth=2,
+        label="Train, naïve interp.",
+    )
+    ax.plot(
+        lambdas,
+        test_loss_interp_naive,
+        linestyle="dashed",
+        color="tab:orange",
+        alpha=0.5,
+        linewidth=2,
+        label="Test, naïve interp.",
+    )
+    ax.plot(
+        lambdas,
+        train_loss_interp_clever,
+        linestyle="solid",
+        color="tab:blue",
+        linewidth=2,
+        label="Train, permuted interp.",
+    )
+    ax.plot(
+        lambdas,
+        test_loss_interp_clever,
+        linestyle="solid",
+        color="tab:orange",
+        linewidth=2,
+        label="Test, permuted interp.",
+    )
+    ax.set_xlabel("$\lambda$")
+    ax.set_xticks([0, 1])
+    ax.set_xticklabels(["Model $A$", "Model $B$"])
+    ax.set_ylabel("Loss")
+    # TODO label x=0 tick as \theta_1, and x=1 tick as \theta_2
+    ax.set_title(f"Loss landscape between the two models (epoch {epoch})")
+    ax.legend(loc="upper right", framealpha=0.5)
+    fig.tight_layout()
+    return fig
+
+
+def plot_interp_acc(
+    epoch,
+    lambdas,
+    train_acc_interp_naive,
+    test_acc_interp_naive,
+    train_acc_interp_clever,
+    test_acc_interp_clever,
+):
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+    ax.plot(
+        lambdas,
+        train_acc_interp_naive,
+        linestyle="dashed",
+        color="tab:blue",
+        alpha=0.5,
+        linewidth=2,
+        label="Train, naïve interp.",
+    )
+    ax.plot(
+        lambdas,
+        test_acc_interp_naive,
+        linestyle="dashed",
+        color="tab:orange",
+        alpha=0.5,
+        linewidth=2,
+        label="Test, naïve interp.",
+    )
+    ax.plot(
+        lambdas,
+        train_acc_interp_clever,
+        linestyle="solid",
+        color="tab:blue",
+        linewidth=2,
+        label="Train, permuted interp.",
+    )
+    ax.plot(
+        lambdas,
+        test_acc_interp_clever,
+        linestyle="solid",
+        color="tab:orange",
+        linewidth=2,
+        label="Test, permuted interp.",
+    )
+    ax.set_xlabel("$\lambda$")
+    ax.set_xticks([0, 1])
+    ax.set_xticklabels(["Model $A$", "Model $B$"])
+    ax.set_ylabel("Accuracy")
+    # TODO label x=0 tick as \theta_1, and x=1 tick as \theta_2
+    ax.set_title(f"Accuracy between the two models (epoch {epoch})")
+    ax.legend(loc="lower right", framealpha=0.5)
+    fig.tight_layout()
+    return fig
+
+
+if __name__ == "__main__":
+    # parser = argparse.ArgumentParser()
+    # parser.add_argument("--seed", type=int, default=0, help="Random seed")
+    # args = parser.parse_args()
+
+    model = ResNet50(n_classes=1000)
+
+    def load_model(filepath):
+        with open(filepath, "rb") as fh:
+            return from_bytes(
+                model.init(random.PRNGKey(0), jnp.zeros((1, 32, 32, 3)))["params"],
+                fh.read(),
+            )
+
+    model_a = pickle.load(open("../a_variables.pkl", "rb"))
+    model_b = pickle.load(open("../b_variables.pkl", "rb"))
+
+    # train_ds, test_ds = load_cifar10()
+
+    permutation_spec = resnet50_permutation_spec()
+
+    @jax.jit
+    def model_apply1(variables, images):
+        return model.apply(variables, images, mutable=["batch_stats"])
+
+    @jax.jit
+    def model_apply2(variables, images):
+        return model.apply(variables, images)
+
+    accs = []
+    for key in range(10):
+        final_permutation = weight_matching(
+            random.PRNGKey(key),
+            permutation_spec,
+            flatten_params(model_a["params"]),
+            flatten_params(model_b["params"]),
+        )
+
+        model_b_clever = model_b["params"]
+        model_b_clever = unflatten_params(
+            apply_permutation(permutation_spec, final_permutation, flatten_params(model_b["params"])))
+
+        dataloader = ImageNet()
+        loss = torch.nn.CrossEntropyLoss()
+
+        # for lam in np.linspace(0, 1, 25):
+        lam = 0.5
+        model_ab = {
+            "params": lerp(lam, model_a["params"], model_b_clever),
+            # "params": model_a["params"],
+            "batch_stats": model_a["batch_stats"]
+        }
+        # from flax.core import unfreeze
+        # model_ab = unfreeze(pickle.load(open("final-perm-interp.pkl", "rb")))
+
+        for (images, labels), _ in zip(dataloader.train_loader, tqdm.trange(100)):
+            images = jnp.moveaxis(jnp.asarray(images.numpy()), 1, 3)
+            y, new_batch_stats = model_apply1(model_ab, images)
+            model_ab["batch_stats"] = new_batch_stats['batch_stats']
+            # logits = torch.tensor(np.asarray(y))
+            # print((labels.unsqueeze(1) == logits.argmax(dim=1, keepdim=True)).sum(), loss(logits, labels))
+
+        acc1 = torchmetrics.Accuracy()
+        acc5 = torchmetrics.Accuracy(top_k=5)
+        sum_loss = 0
+        for images, labels in dataloader.val_loader:
+            images = jnp.moveaxis(jnp.asarray(images.numpy()), 1, 3)
+            y = model_apply2(model_ab, images)
+            logits = torch.tensor(np.asarray(y))
+            sum_loss += loss(logits, labels)
+            acc1(logits, labels)
+            acc5(logits, labels)
+
+            # print({
+            #     # "lambda": lam,
+            #     # "loss": (sum_loss / len(dataloader.val_loader)).item(),
+            #     "acc1": acc1.compute().item(),
+            #     "acc5": acc5.compute().item()
+            # })
+
+        accs.append(acc1.compute().item())
+
+
+# if __name__ == "__main__":
+#   main()

--- a/src/resnet.py
+++ b/src/resnet.py
@@ -1,0 +1,258 @@
+from functools import partial
+from typing import Callable, Optional, Sequence, Tuple
+
+import jax.numpy as jnp
+from flax import linen as nn
+
+from common import ConvBlock, ModuleDef
+# from .splat import SplAtConv2d
+
+STAGE_SIZES = {
+    18: [2, 2, 2, 2],
+    34: [3, 4, 6, 3],
+    50: [3, 4, 6, 3],
+    101: [3, 4, 23, 3],
+    152: [3, 8, 36, 3],
+    200: [3, 24, 36, 3],
+    269: [3, 30, 48, 8],
+}
+
+
+class ResNetStem(nn.Module):
+    conv_block_cls: ModuleDef = ConvBlock
+
+    @nn.compact
+    def __call__(self, x):
+        return self.conv_block_cls(64,
+                                   kernel_size=(7, 7),
+                                   strides=(2, 2),
+                                   padding=[(3, 3), (3, 3)])(x)
+
+
+class ResNetDStem(nn.Module):
+    conv_block_cls: ModuleDef = ConvBlock
+    stem_width: int = 32
+
+    # If True, n_filters for first conv is (input_channels + 1) * 8
+    adaptive_first_width: bool = False
+
+    @nn.compact
+    def __call__(self, x):
+        cls = partial(self.conv_block_cls, kernel_size=(3, 3), padding=((1, 1), (1, 1)))
+        first_width = (8 * (x.shape[-1] + 1)
+                       if self.adaptive_first_width else self.stem_width)
+        x = cls(first_width, strides=(2, 2))(x)
+        x = cls(self.stem_width, strides=(1, 1))(x)
+        x = cls(self.stem_width * 2, strides=(1, 1))(x)
+        return x
+
+
+class ResNetSkipConnection(nn.Module):
+    strides: Tuple[int, int]
+    conv_block_cls: ModuleDef = ConvBlock
+
+    @nn.compact
+    def __call__(self, x, out_shape):
+        if x.shape != out_shape:
+            x = self.conv_block_cls(out_shape[-1],
+                                    kernel_size=(1, 1),
+                                    strides=self.strides,
+                                    activation=lambda y: y)(x)
+        return x
+
+
+class ResNetDSkipConnection(nn.Module):
+    strides: Tuple[int, int]
+    conv_block_cls: ModuleDef = ConvBlock
+
+    @nn.compact
+    def __call__(self, x, out_shape):
+        if self.strides != (1, 1):
+            x = nn.avg_pool(x, (2, 2), strides=(2, 2), padding=((0, 0), (0, 0)))
+        if x.shape[-1] != out_shape[-1]:
+            x = self.conv_block_cls(out_shape[-1], (1, 1), activation=lambda y: y)(x)
+        return x
+
+
+class ResNeStSkipConnection(ResNetDSkipConnection):
+    # Inheritance to ensures our variables dict has the right names.
+    pass
+
+
+class ResNetBlock(nn.Module):
+    n_hidden: int
+    strides: Tuple[int, int] = (1, 1)
+
+    activation: Callable = nn.relu
+    conv_block_cls: ModuleDef = ConvBlock
+    skip_cls: ModuleDef = ResNetSkipConnection
+
+    @nn.compact
+    def __call__(self, x):
+        skip_cls = partial(self.skip_cls, conv_block_cls=self.conv_block_cls)
+        y = self.conv_block_cls(self.n_hidden,
+                                padding=[(1, 1), (1, 1)],
+                                strides=self.strides)(x)
+        y = self.conv_block_cls(self.n_hidden, padding=[(1, 1), (1, 1)],
+                                is_last=True)(y)
+        return self.activation(y + skip_cls(self.strides)(x, y.shape))
+
+
+class ResNetBottleneckBlock(nn.Module):
+    n_hidden: int
+    strides: Tuple[int, int] = (1, 1)
+    expansion: int = 4
+    groups: int = 1  # cardinality
+    base_width: int = 64
+
+    activation: Callable = nn.relu
+    conv_block_cls: ModuleDef = ConvBlock
+    skip_cls: ModuleDef = ResNetSkipConnection
+
+    @nn.compact
+    def __call__(self, x):
+        skip_cls = partial(self.skip_cls, conv_block_cls=self.conv_block_cls)
+        group_width = int(self.n_hidden * (self.base_width / 64.)) * self.groups
+
+        # Downsampling strides in 3x3 conv instead of 1x1 conv, which improves accuracy.
+        # This variant is called ResNet V1.5 (matches torchvision).
+        y = self.conv_block_cls(group_width, kernel_size=(1, 1))(x)
+        y = self.conv_block_cls(group_width,
+                                strides=self.strides,
+                                groups=self.groups,
+                                padding=((1, 1), (1, 1)))(y)
+        y = self.conv_block_cls(self.n_hidden * self.expansion,
+                                kernel_size=(1, 1),
+                                is_last=True)(y)
+        return self.activation(y + skip_cls(self.strides)(x, y.shape))
+
+
+class ResNetDBlock(ResNetBlock):
+    skip_cls: ModuleDef = ResNetDSkipConnection
+
+
+class ResNetDBottleneckBlock(ResNetBottleneckBlock):
+    skip_cls: ModuleDef = ResNetDSkipConnection
+
+
+class ResNeStBottleneckBlock(ResNetBottleneckBlock):
+    skip_cls: ModuleDef = ResNeStSkipConnection
+    avg_pool_first: bool = False
+    radix: int = 2
+
+    splat_cls: ModuleDef = None # SplAtConv2d
+
+    @nn.compact
+    def __call__(self, x):
+        assert self.radix == 2  # TODO: implement radix != 2
+
+        skip_cls = partial(self.skip_cls, conv_block_cls=self.conv_block_cls)
+        group_width = int(self.n_hidden * (self.base_width / 64.)) * self.groups
+
+        y = self.conv_block_cls(group_width, kernel_size=(1, 1))(x)
+
+        if self.strides != (1, 1) and self.avg_pool_first:
+            y = nn.avg_pool(y, (3, 3), strides=self.strides, padding=[(1, 1), (1, 1)])
+
+        y = self.splat_cls(group_width,
+                           kernel_size=(3, 3),
+                           strides=(1, 1),
+                           padding=[(1, 1), (1, 1)],
+                           groups=self.groups,
+                           radix=self.radix)(y)
+
+        if self.strides != (1, 1) and not self.avg_pool_first:
+            y = nn.avg_pool(y, (3, 3), strides=self.strides, padding=[(1, 1), (1, 1)])
+
+        y = self.conv_block_cls(self.n_hidden * self.expansion,
+                                kernel_size=(1, 1),
+                                is_last=True)(y)
+
+        return self.activation(y + skip_cls(self.strides)(x, y.shape))
+
+
+def ResNet(
+    block_cls: ModuleDef,
+    *,
+    stage_sizes: Sequence[int],
+    n_classes: int,
+    hidden_sizes: Sequence[int] = (64, 128, 256, 512),
+    conv_cls: ModuleDef = nn.Conv,
+    norm_cls: Optional[ModuleDef] = partial(nn.BatchNorm, momentum=0.9),
+    conv_block_cls: ModuleDef = ConvBlock,
+    stem_cls: ModuleDef = ResNetStem,
+    pool_fn: Callable = partial(nn.max_pool,
+                                window_shape=(3, 3),
+                                strides=(2, 2),
+                                padding=((1, 1), (1, 1))),
+) -> nn.Sequential:
+    conv_block_cls = partial(conv_block_cls, conv_cls=conv_cls, norm_cls=norm_cls)
+    stem_cls = partial(stem_cls, conv_block_cls=conv_block_cls)
+    block_cls = partial(block_cls, conv_block_cls=conv_block_cls)
+
+    layers = [stem_cls(), pool_fn]
+
+    for i, (hsize, n_blocks) in enumerate(zip(hidden_sizes, stage_sizes)):
+        for b in range(n_blocks):
+            strides = (1, 1) if i == 0 or b != 0 else (2, 2)
+            layers.append(block_cls(n_hidden=hsize, strides=strides))
+
+    layers.append(partial(jnp.mean, axis=(1, 2)))  # global average pool
+    layers.append(nn.Dense(n_classes))
+    return nn.Sequential(layers)
+
+
+# yapf: disable
+ResNet18 = partial(ResNet, stage_sizes=STAGE_SIZES[18],
+                   stem_cls=ResNetStem, block_cls=ResNetBlock)
+ResNet34 = partial(ResNet, stage_sizes=STAGE_SIZES[34],
+                   stem_cls=ResNetStem, block_cls=ResNetBlock)
+ResNet50 = partial(ResNet, stage_sizes=STAGE_SIZES[50],
+                   stem_cls=ResNetStem, block_cls=ResNetBottleneckBlock)
+ResNet101 = partial(ResNet, stage_sizes=STAGE_SIZES[101],
+                    stem_cls=ResNetStem, block_cls=ResNetBottleneckBlock)
+ResNet152 = partial(ResNet, stage_sizes=STAGE_SIZES[152],
+                    stem_cls=ResNetStem, block_cls=ResNetBottleneckBlock)
+ResNet200 = partial(ResNet, stage_sizes=STAGE_SIZES[200],
+                    stem_cls=ResNetStem, block_cls=ResNetBottleneckBlock)
+
+WideResNet50 = partial(ResNet50, hidden_sizes=(128, 256, 512, 1024),
+                       block_cls=partial(ResNetBottleneckBlock, expansion=2))
+WideResNet101 = partial(ResNet101, hidden_sizes=(128, 256, 512, 1024),
+                        block_cls=partial(ResNetBottleneckBlock, expansion=2))
+
+ResNeXt50 = partial(ResNet50,
+                    block_cls=partial(ResNetBottleneckBlock, groups=32, base_width=4))
+ResNeXt101 = partial(ResNet101,
+                     block_cls=partial(ResNetBottleneckBlock, groups=32, base_width=8))
+
+ResNetD18 = partial(ResNet, stage_sizes=STAGE_SIZES[18],
+                    stem_cls=ResNetDStem, block_cls=ResNetDBlock)
+ResNetD34 = partial(ResNet, stage_sizes=STAGE_SIZES[34],
+                    stem_cls=ResNetDStem, block_cls=ResNetDBlock)
+ResNetD50 = partial(ResNet, stage_sizes=STAGE_SIZES[50],
+                    stem_cls=ResNetDStem, block_cls=ResNetDBottleneckBlock)
+ResNetD101 = partial(ResNet, stage_sizes=STAGE_SIZES[101],
+                     stem_cls=ResNetDStem, block_cls=ResNetDBottleneckBlock)
+ResNetD152 = partial(ResNet, stage_sizes=STAGE_SIZES[152],
+                     stem_cls=ResNetDStem, block_cls=ResNetDBottleneckBlock)
+ResNetD200 = partial(ResNet, stage_sizes=STAGE_SIZES[200],
+                     stem_cls=ResNetDStem, block_cls=ResNetDBottleneckBlock)
+
+ResNeSt50Fast = partial(ResNet, stage_sizes=STAGE_SIZES[50],
+                        stem_cls=ResNetDStem,
+                        block_cls=partial(ResNeStBottleneckBlock, avg_pool_first=True))
+ResNeSt50 = partial(ResNet, stage_sizes=STAGE_SIZES[50],
+                    stem_cls=ResNetDStem, block_cls=ResNeStBottleneckBlock)
+ResNeSt101 = partial(ResNet, stage_sizes=STAGE_SIZES[101],
+                     stem_cls=partial(ResNetDStem, stem_width=64),
+                     block_cls=ResNeStBottleneckBlock)
+ResNeSt152 = partial(ResNet, stage_sizes=STAGE_SIZES[152],
+                     stem_cls=partial(ResNetDStem, stem_width=64),
+                     block_cls=ResNeStBottleneckBlock)
+ResNeSt200 = partial(ResNet, stage_sizes=STAGE_SIZES[200],
+                     stem_cls=partial(ResNetDStem, stem_width=64),
+                     block_cls=ResNeStBottleneckBlock)
+ResNeSt269 = partial(ResNet, stage_sizes=STAGE_SIZES[269],
+                     stem_cls=partial(ResNetDStem, stem_width=64),
+                     block_cls=ResNeStBottleneckBlock)

--- a/src/resnet.py
+++ b/src/resnet.py
@@ -1,3 +1,8 @@
+"""
+This code is copied (almost) verbatim from https://github.com/n2cholas/jax-resnet/
+It is only used for our resnet50 experiments on ImageNet.
+"""
+
 from functools import partial
 from typing import Callable, Optional, Sequence, Tuple
 

--- a/src/weight_matching.py
+++ b/src/weight_matching.py
@@ -118,34 +118,34 @@ def resnet50_permutation_spec() -> PermutationSpec:
 
   # This is for easy blocks that use a residual connection, without any change in the number of channels.
   easyblock = lambda name, p: {
-      **conv(f"{name}/conv1", p, f"P_{name}_inner1"),
-      **norm(f"{name}/norm1", f"P_{name}_inner1"),
+      **conv(f"{name}/ConvBlock_0/Conv_0", p, f"P_{name}_inner1"),
+      **norm(f"{name}/ConvBlock_0/BatchNorm_0", f"P_{name}_inner1"),
       #
-      **conv(f"{name}/conv2", f"P_{name}_inner1", f"P_{name}_inner2"),
-      **norm(f"{name}/norm2", f"P_{name}_inner2"),
+      **conv(f"{name}/ConvBlock_1/Conv_0", f"P_{name}_inner1", f"P_{name}_inner2"),
+      **norm(f"{name}/ConvBlock_1/BatchNorm_0", f"P_{name}_inner2"),
       #
-      **conv(f"{name}/conv3", f"P_{name}_inner2", p),
-      **norm(f"{name}/norm3", p),
+      **conv(f"{name}/ConvBlock_2/Conv_0", f"P_{name}_inner2", p),
+      **norm(f"{name}/ConvBlock_2/BatchNorm_0", p),
   }
 
   # This is for blocks that use a residual connection, but change the number of channels via a Conv.
   shortcutblock = lambda name, p_in, p_out: {
-      **conv(f"{name}/conv1", p_in, f"P_{name}_inner1"),
-      **norm(f"{name}/norm1", f"P_{name}_inner1"),
-      #
-      **conv(f"{name}/conv2", f"P_{name}_inner1", f"P_{name}_inner2"),
-      **norm(f"{name}/norm2", f"P_{name}_inner2"),
-      #
-      **conv(f"{name}/conv2", f"P_{name}_inner2", p_out),
-      **norm(f"{name}/norm2", p_out),
-      #
-      **conv(f"{name}/shortcut/layers_0", p_in, p_out),
-      **norm(f"{name}/shortcut/layers_1", p_out),
+    **conv(f"{name}/ConvBlock_0/Conv_0", p_in, f"P_{name}_inner1"),
+    **norm(f"{name}/ConvBlock_0/BatchNorm_0", f"P_{name}_inner1"),
+    #
+    **conv(f"{name}/ConvBlock_1/Conv_0", f"P_{name}_inner1", f"P_{name}_inner2"),
+    **norm(f"{name}/ConvBlock_1/BatchNorm_0", f"P_{name}_inner2"),
+    #
+    **conv(f"{name}/ConvBlock_2/Conv_0", f"P_{name}_inner2", p_out),
+    **norm(f"{name}/ConvBlock_2/BatchNorm_0", p_out),
+    #
+    **conv(f"{name}/ResNetSkipConnection_0/ConvBlock_0/Conv_0", p_in, p_out),
+    **norm(f"{name}/ResNetSkipConnection_0/ConvBlock_0/BatchNorm_0", p_out),
   }
 
   return permutation_spec_from_axes_to_perm({
-      **conv("conv1", None, "P_bg0"),
-      **norm("norm1", "P_bg0"),
+      **conv("layers_0/ConvBlock_0/Conv_0", None, "P_bg0"),
+      **norm("layers_0/ConvBlock_0/BatchNorm_0", "P_bg0"),
       #
       **shortcutblock("blockgroups_0/blocks_0", "P_bg0", "P_bg1"),
       **easyblock("blockgroups_0/blocks_1", "P_bg1"),


### PR DESCRIPTION
The permutation spec for ResNet50 we provided was different than the one we actually used. As far as we know, there is no corresponding model for that permutation spec. This PR replaces the spec with the one we actually used for the experiments in the paper and adds the scripts required to reproduce our results. This also addresses #10.